### PR TITLE
fix(nosapi_blackbox): use `serde_tuple_explicit` instead of git fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "serde_tuple",
+ "serde_tuple_explicit",
  "serde_with",
  "sha2",
  "thiserror",
@@ -706,18 +706,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_tuple"
+name = "serde_tuple_explicit"
 version = "1.1.0"
-source = "git+https://github.com/zakuciael/serde_tuple#18e93ceeb89828c93fb9ddc9a5fcca0eed3b0396"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0faba8fe8d21ebf46a5f484528ef6c3b5230710689bf26b0b205b613a4f7fa5"
 dependencies = [
  "serde",
- "serde_tuple_macros",
+ "serde_tuple_explicit_macros",
 ]
 
 [[package]]
-name = "serde_tuple_macros"
+name = "serde_tuple_explicit_macros"
 version = "1.0.1"
-source = "git+https://github.com/zakuciael/serde_tuple#18e93ceeb89828c93fb9ddc9a5fcca0eed3b0396"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f838cab444f40a9ab19e5c56a6546fee364dc90ce7a92b64c4a9f5fe9bdaadd4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/nosapi_blackbox/Cargo.toml
+++ b/crates/nosapi_blackbox/Cargo.toml
@@ -13,7 +13,7 @@ rand = { version = "0.8.5", features = ["serde"] }
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.134"
 serde_plain = "1.0.2"
-serde_tuple = { version = "1.1.0", git = "https://github.com/zakuciael/serde_tuple" }
+serde_tuple_explicit = { version = "1.1.0" }
 serde_with = { version = "3.12.0", features = ["base64"] }
 percent-encoding = "2.3.1"
 sha2 = "0.10.8"

--- a/crates/nosapi_blackbox/src/blackbox/de.rs
+++ b/crates/nosapi_blackbox/src/blackbox/de.rs
@@ -3,7 +3,7 @@ use crate::fingerprint::Fingerprint;
 use base64::Engine;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
-use serde_tuple::DeserializeTuple;
+use serde_tuple_explicit::DeserializeTuple;
 use std::fmt::Formatter;
 
 impl<'de> Deserialize<'de> for Blackbox {

--- a/crates/nosapi_blackbox/src/blackbox/ser.rs
+++ b/crates/nosapi_blackbox/src/blackbox/ser.rs
@@ -11,9 +11,9 @@ impl Serialize for Blackbox {
     let fingerprint_str = {
       let mut buf = Vec::new();
       let mut serializer = serde_json::Serializer::new(&mut buf);
-      serde_tuple::SerializeTuple::serialize_tuple(&self.0, &mut serializer).map_err(|err| {
-        serde::ser::Error::custom(format!("failed to serialize fingerprint: {}", err))
-      })?;
+      serde_tuple_explicit::SerializeTuple::serialize_tuple(&self.0, &mut serializer).map_err(
+        |err| serde::ser::Error::custom(format!("failed to serialize fingerprint: {}", err)),
+      )?;
 
       // It's safe to call `from_utf8_unchecked` since serde_json does the same under the hood
       unsafe { String::from_utf8_unchecked(buf) }

--- a/crates/nosapi_blackbox/src/fingerprint/mod.rs
+++ b/crates/nosapi_blackbox/src/fingerprint/mod.rs
@@ -1,7 +1,7 @@
 use crate::vector::VectorString;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_tuple::{DeserializeTuple, SerializeTuple};
+use serde_tuple_explicit::{DeserializeTuple, SerializeTuple};
 use serde_with::base64::{Base64, Standard};
 use serde_with::serde_as;
 
@@ -57,7 +57,7 @@ mod tests {
   use crate::fingerprint::Fingerprint;
   use crate::vector::VectorString;
   use chrono::DateTime;
-  use serde_tuple::{DeserializeTuple, SerializeTuple};
+  use serde_tuple_explicit::{DeserializeTuple, SerializeTuple};
   use std::str::FromStr;
 
   #[rstest::fixture]


### PR DESCRIPTION
# Description
This PR replaces the git fork of `serde_tuple` with a published version of the fork called `serde_tuple_explicit`
