### PR TITLE
chore: add config files for `taplo` and `conventionalcommit`

### DIFF
--- a/conventionalcommit.json
+++ b/conventionalcommit.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://github.com/lppedd/idea-conventional-commit/raw/master/src/main/resources/defaults/conventionalcommit.schema.json",
+  "types": {
+    "refactor": {
+      "description": "Changes which neither fix a bug nor add a feature"
+    },
+    "fix": {
+      "description": "Changes which patch a bug"
+    },
+    "feat": {
+      "description": "Changes which introduce a new feature"
+    },
+    "build": {
+      "description": "Changes which affect the build system or external dependencies.<br>Example scopes: gulp, broccoli, npm",
+      "scopes": {
+        "npm": {},
+        "gulp": {},
+        "broccoli": {}
+      }
+    },
+    "chore": {
+      "description": "Changes which are not user-facing"
+    },
+    "style": {
+      "description": "Changes which do not affect code logic, such as whitespaces, formatting, missing semicolons"
+    },
+    "test": {
+      "description": "Changes which add missing tests or fix existing ones"
+    },
+    "docs": {
+      "description": "Changes which affect documentation"
+    },
+    "perf": {
+      "description": "Changes which improve performance"
+    },
+    "ci": {
+      "description": "Changes which affect CI configuration files and scripts.<br>Example scopes: travis, circle, browser-stack, sauce-labs"
+    },
+    "revert": {
+      "description": "Changes which revert a previous commit"
+    }
+  },
+  "commonScopes": {
+    "deps": {
+      "description": "Update to dependencies"
+    },
+    "readme": {
+      "description": "Updates to README files"
+    },
+    "nosapi_blackbox": {
+      "description": "Updates to nosapi_blackbox create"
+    }
+  },
+  "footerTypes": [
+    {
+      "name": "BREAKING-CHANGE",
+      "description": "The commit introduces breaking API changes"
+    },
+    {
+      "name": "Closes",
+      "description": "The commit closes issues or pull requests"
+    },
+    {
+      "name": "Implements",
+      "description": "The commit implements features"
+    },
+    {
+      "name": "Author",
+      "description": "The commit's author"
+    },
+    {
+      "name": "Co-authored-by",
+      "description": "The specified person co-authored the commit's changes"
+    },
+    {
+      "name": "Signed-off-by",
+      "description": "A signoff may certify that the committer has the rights to submit the work under the project's license or agrees to some contributor representation, such as a Developer Certificate of Origin"
+    },
+    {
+      "name": "Acked-by",
+      "description": "The specified person liked the commit's changes"
+    },
+    {
+      "name": "Reviewed-by",
+      "description": "The specified person reviewed and is completely satisfied with the commit's changes"
+    },
+    {
+      "name": "Tested-by",
+      "description": "The specified person applied the commit's changes and found them to have the desired effect"
+    },
+    {
+      "name": "Refs",
+      "description": "The commit references another commit by its hash ID.<br>For multiple hash IDs, use a comma as separator"
+    }
+  ]
+}

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,3 @@
+[formatting]
+array_auto_collapse = false
+array_auto_expand = false


### PR DESCRIPTION
# Description
This PR adds config files for `taplo` and `conventionalcommit`