### PR TITLE
fix(ci): add `--git-token` and `--forge` args to `release-plz` commands

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,10 +34,8 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.10
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
-      - name: Run release-plz
-        run: devenv shell release-plz release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release
+        run: devenv shell release-plz release --git-token "${{ secrets.GITHUB_TOKEN }}" --forge github
 
   release-plz-pr:
     name: Release-plz PR
@@ -65,7 +63,5 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.10
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
-      - name: Run release-plz
-        run: devenv shell release-plz release-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release PR
+        run: devenv shell release-plz release-pr --git-token "${{ secrets.GITHUB_TOKEN }}" --forge github


### PR DESCRIPTION
### TL;DR

Updated `release-plz` commands to pass the GitHub token and forge explicitly as CLI arguments instead of environment variables.

### What changed?

The `release-plz release` and `release-plz release-pr` commands now pass `--git-token` and `--forge github` as direct CLI flags rather than relying on the `GITHUB_TOKEN` environment variable.

### Why make this change?

When running `release-plz` as a CLI command the `GITHUB_TOKEN` needs to be specified in the `--git-token` argument instead of the `GITHUB_TOKEN` env variable.