### PR TITLE
fix(ci): add required permissions to create PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   id-token: write
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   release-plz-release:


### PR DESCRIPTION
### TL;DR

Grant write permissions for pull requests in the CD workflow.

### What changed?

The `pull-requests` permission in the CD workflow has been updated from `read` to `write`.

### Why make this change?

The `release-plz` action requires write access to pull requests in order to create and update release pull requests automatically. The previous `read` permission was insufficient for this operation.