### PR TITLE
chore(devenv): add `cargo-semver-checks` package to devshell

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -73,6 +73,7 @@ in
   packages = with pkgs; [
     cargo-nextest
     cargo-msrv
+    cargo-semver-checks
     release-plz
     config.languages.rust.toolchainPackage
   ];


### PR DESCRIPTION
### TL;DR

Added `cargo-semver-checks` to the development environment packages.

### What changed?

`cargo-semver-checks` has been added to the list of packages available in the `devenv.sh` development shell.

### Why make this change?

`cargo-semver-checks` allows developers to lint Rust crates for semver compliance, ensuring that any API changes are properly reflected in version bumps. This is especially useful alongside `release-plz` to catch unintentional breaking changes before publishing a new release.