### PR TITLE
chore(ci): add `release-plz` config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ devenv.local.yaml
 # direnv
 .direnv
 
-# pre-commit
+# Generated config files
 .pre-commit-config.yaml
+.release-plz.toml

--- a/devenv.nix
+++ b/devenv.nix
@@ -211,4 +211,20 @@ in
       };
     };
   };
+
+  files = {
+    ".release-plz.toml".toml = {
+      workspace = {
+        semver_check = true;
+        git_release_enable = true;
+        git_release_name = "{{ package }} v{{ version }}";
+        git_tag_enable = true;
+        git_tag_name = "{{ package }}/v{{ version }}";
+        pr_branch_prefix = "release-";
+        pr_labels = [ "📚 type: release" ];
+        changelog_update = true;
+        release_always = false; # Publish crates only when merging the Release PR
+      };
+    };
+  };
 }


### PR DESCRIPTION
### TL;DR

Adds a generated `release-plz` configuration file via `devenv` and updates  `.gitignore` to exclude it.

### What changed?

A `.release-plz.toml` configuration is now generated through `devenv`'s `files` option.

The `.gitignore` comment for pre-commit was broadened to "Generated config files" to also cover the newly generated `.release-plz.toml`.

### Why make this change?

The configuration sets up workspace-level release automation with semantic versioning checks, Git releases and tags using `{{ package }}/v{{ version }}` naming conventions, release PR branch prefixing, changelog updates, and a `📚 type: release` label on release PRs. Crate publishing is gated behind merging the Release PR (`release_always = false`).